### PR TITLE
Add custom matcher to see if job has run

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ describe Clockwork do
 
     expect(Clockwork::Test.times_run("Run a job").to eq 60
   end
+
+  describe "RSpec Custom Matcher" do
+    subject(:clockwork) { Clockwork::Test }
+
+    before { Clockwork::Test.run(max_ticks: 1) }
+
+    it { should have_run("Run a job") }
+    it { should have_run("Run a job").once }
+
+    it { should_not have_run("Run a job").exactly(2).times }
+  end
 end
 ```
 
@@ -140,6 +151,30 @@ If the job "test_job" never ran, `times_run("test_job")` will be 0; otherwise, i
 `block_for` returns the block that would be handled and run on each execution of a job. This can be useful for ensuring that the block you associated with an event does whatever it is that you expect it to do.
 
 If the job "test_job" never ran, `block_for("test_job")` will return an empty proc; otherwise, the block of code that the event would run is returned, which can then be `call`ed to test.
+
+### RSpec Matchers
+
+`Clockwork::Test` includes a rspec test matcher to check if a job has been run.
+
+To use, add the following to your `spec_helper.rb`:
+
+```ruby
+RSpec.configure do |config|
+  config.include(Clockwork::Test::RSpec::Matchers)
+end
+```
+
+The `have_run` matcher checks if a job by the name provided has been run, and allows for a specific number of times to be checked against.
+
+`expect(Clockwork::Test).to have_run("Job Name").exactly(42).times`
+
+You can alternatively pass the number of times in as an optional argument in the `have_run` method, as such:
+
+`expect(Clockwork::Test).to have_run("Job Name", times: 42)`
+
+If you do not pass the number of times, either with a chained method call or as an optional argument to `have_run`, the matcher will just check if the job was run at all. It provides no assertion as to how often it was run, just that it's at least once.
+
+Chaining `once` to `have_run` will check that the job was run one time only.
 
 ### Resetting the clock
 

--- a/lib/clockwork/test.rb
+++ b/lib/clockwork/test.rb
@@ -5,6 +5,7 @@ require "clockwork/test/event"
 require "clockwork/test/job_history"
 require "clockwork/test/manager"
 require "clockwork/test/version"
+require "clockwork/test/rspec/matchers"
 
 module Clockwork
   module Methods

--- a/lib/clockwork/test/rspec/matchers.rb
+++ b/lib/clockwork/test/rspec/matchers.rb
@@ -1,0 +1,13 @@
+require "clockwork/test/rspec/matchers/have_run"
+
+module Clockwork
+  module Test
+    module RSpec
+      module Matchers
+        def have_run(job, opts = {})
+          Matchers::HaveRun.new(job, opts)
+        end
+      end
+    end
+  end
+end

--- a/lib/clockwork/test/rspec/matchers/have_run.rb
+++ b/lib/clockwork/test/rspec/matchers/have_run.rb
@@ -1,0 +1,67 @@
+module Clockwork
+  module Test
+    module RSpec
+      module Matchers
+        class HaveRun
+          def initialize(job_name = nil, opts = {})
+            @job_name = job_name
+            @times_run = opts[:times] || 1
+            @exactly = false
+          end
+
+          def matches?(clock_test)
+            if @exactly
+              clock_test.manager.times_run(@job_name) == @times_run
+            else
+              clock_test.manager.ran_job?(@job_name)
+            end
+          end
+
+          def once
+            @times_run = 1
+            @exactly = true
+
+            self
+          end
+
+          def exactly(times)
+            @times_run = times
+            @exactly = true
+
+            self
+          end
+
+          def times(times = nil)
+            if times
+              @times_run = times
+              @exactly = true
+            end
+
+            self
+          end
+
+          def time(times = nil)
+            if times
+              @times_run = times
+              @exactly = true
+            end
+
+            self
+          end
+
+          def description
+            "run \"#{@job_name}\" #{@times_run} #{@times_run == 1 ? 'time' : 'times'}"
+          end
+
+          def failure_message
+            "expected Clockwork::Test to have " + description
+          end
+
+          def failure_message_when_negated
+            "expected Clockwork::Test to not have run \"#{@job_name}\"."
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/clock_spec.rb
+++ b/spec/acceptance/clock_spec.rb
@@ -2,12 +2,12 @@ require "spec_helper"
 
 describe "Clockwork" do
   let(:clock_file) { "spec/fixtures/clock.rb" }
+  let(:test_job_name) { "Run a job" }
+
+  after(:each) { Clockwork::Test.clear! }
 
   describe "Run a job" do
-    let(:test_job_name) { "Run a job" }
-
     before { Clockwork::Test.run(file: clock_file, max_ticks: 1) }
-    after { Clockwork::Test.clear! }
 
     it "runs the test job in the file" do
       expect(Clockwork::Test.ran_job?(test_job_name)).to be_truthy
@@ -19,6 +19,32 @@ describe "Clockwork" do
 
     it "retains a record of the work that the job would have done" do
       expect(Clockwork::Test.block_for(test_job_name).call).to eq "Here's a running job"
+    end
+  end
+
+  describe "Custom matchers" do
+    subject(:clockwork) { Clockwork::Test }
+
+    before { Clockwork::Test.run(file: clock_file, max_ticks: 1) }
+
+    it { should have_run(test_job_name) }
+    it { should have_run(test_job_name).once }
+
+    it { should_not have_run(test_job_name).exactly(2).times }
+
+    it "works as an explicit expectation as well" do
+      expect(Clockwork::Test).to have_run(test_job_name)
+      expect(Clockwork::Test).to_not have_run(test_job_name).exactly(2).times
+    end
+
+    context "running multiple times" do
+      before { Clockwork::Test.run(file: clock_file, max_ticks: 2, tick_speed: 1.minute) }
+
+      it { should have_run(test_job_name).exactly(2).times }
+      it { should have_run(test_job_name) }
+      it { should have_run(test_job_name).times(2) }
+      it { should have_run(test_job_name).exactly(2) }
+      it { should have_run(test_job_name, times: 2) }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,3 +3,7 @@ require 'clockwork/test'
 
 require 'pry'
 require 'rspec/its'
+
+RSpec.configure do |config|
+  config.include(Clockwork::Test::RSpec::Matchers)
+end


### PR DESCRIPTION
This commit provides an rspec matcher that can be used to see if a job
has run or not a specific number of times.