### PR TITLE
Pass clockwork config to Clockwork::Test

### DIFF
--- a/lib/clockwork/test.rb
+++ b/lib/clockwork/test.rb
@@ -13,6 +13,11 @@ module Clockwork
       ::Clockwork.manager.every(period, job, options, &block)
       ::Clockwork::Test.manager.every(period, job, options, &block)
     end
+
+    def configure(&block)
+      ::Clockwork.manager.configure(&block)
+      ::Clockwork::Test.manager.configure(&block)
+    end
   end
 
   module Test
@@ -46,7 +51,8 @@ module Clockwork
         }
 
         # TODO parse file rather than loading it
-        # and overloading Clockwork::Methods::every
+        # and overloading Clockwork::Methods::every 
+        # and Clockwork::Methods::configure
         load file
 
         manager.run(run_opts)

--- a/lib/clockwork/test/manager.rb
+++ b/lib/clockwork/test/manager.rb
@@ -9,18 +9,20 @@ module Clockwork
 
         @total_ticks = 0
         @max_ticks = opts[:max_ticks]
+        @start_time = opts[:start_time]
         @end_time = opts[:end_time]
         config[:logger].level = Logger::ERROR
       end
 
       def run(opts = {})
         @max_ticks = opts[:max_ticks] if opts[:max_ticks]
+        @start_time = opts[:start_time] if opts[:start_time]
         @end_time = opts[:end_time] if opts[:end_time]
         @tick_speed = opts[:tick_speed]
 
-        if opts[:start_time]
+        if @start_time
           @time_altered = true
-          Timecop.travel(opts[:start_time])
+          Timecop.travel(@start_time)
         end
 
         super()

--- a/spec/acceptance/clock_spec.rb
+++ b/spec/acceptance/clock_spec.rb
@@ -47,4 +47,35 @@ describe "Clockwork" do
       it { should have_run(test_job_name, times: 2) }
     end
   end
+
+  describe "Run at certain time" do
+    subject(:clockwork) { Clockwork::Test }
+
+    before(:each) do
+      Time.zone = time_zone
+
+      Clockwork::Test.run(clock_opts)
+    end
+
+    after(:each) { Clockwork::Test.clear! }
+
+    let(:clock_opts) { { file: clock_file, start_time: start_time, max_ticks: 1 } }
+
+    let(:time_zone) { "US/Eastern" }
+    let(:start_time) { Time.zone.local(2008, 9, 1, 17, 30, 0) }
+
+    it { should have_run("Run at certain time").once }
+
+    context "before the job should be run" do
+      let(:start_time) { Time.zone.local(2015, 9, 13, 17, 29, 59) }
+
+      it { should_not have_run("Run at certain time") }
+    end
+
+    context "after the job should be run" do
+      let(:start_time) { Time.zone.local(2015, 9, 13, 17, 31, 0) }
+
+      it { should_not have_run("Run at certain time") }
+    end
+  end
 end

--- a/spec/fixtures/clock.rb
+++ b/spec/fixtures/clock.rb
@@ -10,4 +10,8 @@ module Clockwork
   every(1.minute, "Run a job") do
     "Here's a running job"
   end
+
+  every(1.day, "Run at certain time", at: "17:30") do
+    "Run at certain time"
+  end
 end


### PR DESCRIPTION
This modification ensures that the loading of the clock file will pass
any configuration options set in to Clockwork::Test::Manager.

Previously, when the clock.rb was loaded, the config block was ignored.
This presents an issue when details in the configuration are required to
know if a job should run or not - most prominently with the time zone.

This manifested itself with events not having a timezone configured
when a default TZ was defined in the config. Tests against jobs that
should run at certain times would fail, because the time passed in would
not be parsed at the appropriate timezone in the event, and the event
would assert that it should not run when it should, were the proper
global timezone from the config passed to it.

Test coverage has been added with an acceptance test checking if a job
set to run at a certain time, in a specific timezone associated with the
global config, correctly runs.