### PR TITLE
DRY up custom matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Current release (in development)
 
+* Refactor custom matcher to remove repeated code [#8](https://github.com/kevin-j-m/clockwork-test/pull/8)
+
+  *Kevin Murphy*
+
 ## 0.1.1
 
 * Pass clock file configuration to Clockwork::Test::Manager [#7](https://github.com/kevin-j-m/clockwork-test/pull/7)

--- a/lib/clockwork/test/rspec/matchers/have_run.rb
+++ b/lib/clockwork/test/rspec/matchers/have_run.rb
@@ -18,26 +18,15 @@ module Clockwork
           end
 
           def once
-            @times_run = 1
-            @exactly = true
-
-            self
+            time(1)
           end
 
           def exactly(times)
-            @times_run = times
-            @exactly = true
-
-            self
+            time(times)
           end
 
           def times(times = nil)
-            if times
-              @times_run = times
-              @exactly = true
-            end
-
-            self
+            time(times)
           end
 
           def time(times = nil)


### PR DESCRIPTION
This commit removes repeated code in the have_run custom matcher. Many
of the chainable operations complete the same function, and as such,
have been modified to all call the same base operation.