### PR TITLE
Add ruby 2.3 to the Travis testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3.0
   - ruby-head
 script:
   - bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
   *Kevin Murphy*
 
+* Test against ruby 2.3 explicitly [#9](https://github.com/kevin-j-m/clockwork-test/pull/9)
+
+  *Kevin Murphy*
+
 ## 0.1.1
 
 * Pass clock file configuration to Clockwork::Test::Manager [#7](https://github.com/kevin-j-m/clockwork-test/pull/7)


### PR DESCRIPTION
This change adds ruby 2.3 to the tests run on Travis. Head is still
tested, but now that 2.3 has been released, we should explicitly check
that 2.3 remains compatible as head will start to drift.