### PR TITLE
Avoid changing global time zone state

### DIFF
--- a/spec/acceptance/clock_spec.rb
+++ b/spec/acceptance/clock_spec.rb
@@ -52,9 +52,7 @@ describe "Clockwork" do
     subject(:clockwork) { Clockwork::Test }
 
     before(:each) do
-      Time.zone = time_zone
-
-      Clockwork::Test.run(clock_opts)
+      Time.use_zone(time_zone) { Clockwork::Test.run(clock_opts) }
     end
 
     after(:each) { Clockwork::Test.clear! }


### PR DESCRIPTION
By assigning `Time.zone` in a `before`, we're changing the global state of which time zone is in use for any other code which relies on it. This should avoid that by instead relying on the block form of `use_zone`.

Note that this only works because of the slightly quirky way that test examples save state in the `Clockwork::Test` subject, and the way that `Clockwork::Test.run` is the thing running the relevant example. In an ordinary test setup, the `use_zone` block be called, _then_ the RSpec example executed. That would require the use of

```ruby
around(:each) do |example|
  orig_zone = Time.zone
  Time.zone = time_zone

  example.run

  Time.zone = orig_zone
end
```

It isn't needed here though, so `use_zone` should be fine, and it has less bookkeeping.