### PR TITLE
Update appraisal post-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Current release (in development)
 
+* Introduce release process documentation [#14](https://github.com/kevin-j-m/clockwork-test/pull/14)
+
+  *Kevin Murphy*
+
 ## 0.2.0
 
 * Refactor custom matcher to remove repeated code [#8](https://github.com/kevin-j-m/clockwork-test/pull/8)

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,6 @@
+* Bump version number in `lib/clockwork/test/version.rb`.
+* Update the [CHANGELOG](CHANGELOG.md), moving the current release work to under the version number.
+* Update appraisal gemfiles with the new version number `appraisal install`.
+* Run tests across all clockwork versions `appraisal rake`.
+* Push the release to RubyGems `rake release`.
+* Check the RubyGems [twitter account](https://twitter.com/rubygems) to publicize the release.

--- a/gemfiles/clockwork_1_3_1.gemfile.lock
+++ b/gemfiles/clockwork_1_3_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    clockwork-test (0.1.1)
+    clockwork-test (0.2.0)
       clockwork
       timecop
 

--- a/gemfiles/clockwork_2_0_0.gemfile.lock
+++ b/gemfiles/clockwork_2_0_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    clockwork-test (0.1.1)
+    clockwork-test (0.2.0)
       clockwork
       timecop
 

--- a/gemfiles/clockwork_2_0_1.gemfile.lock
+++ b/gemfiles/clockwork_2_0_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    clockwork-test (0.1.1)
+    clockwork-test (0.2.0)
       clockwork
       timecop
 

--- a/gemfiles/clockwork_2_0_2.gemfile.lock
+++ b/gemfiles/clockwork_2_0_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    clockwork-test (0.1.1)
+    clockwork-test (0.2.0)
       clockwork
       timecop
 


### PR DESCRIPTION
* This updates the appraisal gem files to reference the proper
clockwork-test version post-release of 0.2.0. I neglected to do so when
pushing the release, which as a result is causing CI to fail.
* Documents the process to follow when releasing a new version of the
gem. This should cut down on the effort involved in remembering
everything to do when releasing a new version and provide a consistent
process.