### PR TITLE
Add require to test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ end
 The following tests may be run against it:
 
 ```ruby
+require "clockwork/test"
+
 describe Clockwork do
   after(:each) { Clockwork::Test.clear! }
 


### PR DESCRIPTION
For folks new to Ruby this can be tricky to remember: you replace the `-` with a `/` when requiring gems. Since the `clock.rb` example included the clockwork gem I thought it made sense to have the example test include the clockwork-test gem as well.