### PR TITLE
Include activesupport as dev dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   *Kevin Murphy*
 
+* Add activesupport as dev dependency [#19](https://github.com/kevin-j-m/clockwork-test/pull/19)
+
+  *Kevin Murphy*
+
 ## 0.2.0
 
 * Refactor custom matcher to remove repeated code [#8](https://github.com/kevin-j-m/clockwork-test/pull/8)

--- a/clockwork-test.gemspec
+++ b/clockwork-test.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "activesupport"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/gemfiles/clockwork_1_3_1.gemfile.lock
+++ b/gemfiles/clockwork_1_3_1.gemfile.lock
@@ -58,6 +58,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   appraisal
   bundler (~> 1.7)
   clockwork (= 1.3.1)
@@ -68,4 +69,4 @@ DEPENDENCIES
   rspec-its
 
 BUNDLED WITH
-   1.14.6
+   1.16.0

--- a/gemfiles/clockwork_2_0_0.gemfile.lock
+++ b/gemfiles/clockwork_2_0_0.gemfile.lock
@@ -58,6 +58,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   appraisal
   bundler (~> 1.7)
   clockwork (= 2.0.0)
@@ -68,4 +69,4 @@ DEPENDENCIES
   rspec-its
 
 BUNDLED WITH
-   1.14.6
+   1.16.0

--- a/gemfiles/clockwork_2_0_1.gemfile.lock
+++ b/gemfiles/clockwork_2_0_1.gemfile.lock
@@ -58,6 +58,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   appraisal
   bundler (~> 1.7)
   clockwork (= 2.0.1)
@@ -68,4 +69,4 @@ DEPENDENCIES
   rspec-its
 
 BUNDLED WITH
-   1.14.6
+   1.16.0

--- a/gemfiles/clockwork_2_0_2.gemfile.lock
+++ b/gemfiles/clockwork_2_0_2.gemfile.lock
@@ -58,6 +58,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   appraisal
   bundler (~> 1.7)
   clockwork (= 2.0.2)
@@ -68,4 +69,4 @@ DEPENDENCIES
   rspec-its
 
 BUNDLED WITH
-   1.14.6
+   1.16.0

--- a/gemfiles/clockwork_master.gemfile.lock
+++ b/gemfiles/clockwork_master.gemfile.lock
@@ -15,13 +15,22 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.1.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     appraisal (2.2.0)
       bundler
       rake
       thor (>= 0.14.0)
     coderay (1.1.2)
+    concurrent-ruby (1.0.5)
     diff-lcs (1.3)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
     method_source (0.9.0)
+    minitest (5.10.3)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -52,6 +61,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   appraisal
   bundler (~> 1.7)
   clockwork!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,9 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'clockwork/test'
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "clockwork/test"
 
-require 'pry'
-require 'rspec/its'
+require "active_support/time"
+require "pry"
+require "rspec/its"
 
 RSpec.configure do |config|
   config.include(Clockwork::Test::RSpec::Matchers)


### PR DESCRIPTION
activesupport is no longer a dependency in the latest clockwork. This
adds activesupport as a development dependency for use in tests to
configure the `every` time that tests should be run against.