### PR TITLE
Update ruby point versions to test against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
   - ruby-head
 script:
   - bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
   *Kevin Murphy*
 
+* Update ruby point versions in testing matrix [#22](https://github.com/kevin-j-m/clockwork-test/pull/22)
+
+  *Kevin Murphy*
+
 ## 0.2.0
 
 * Refactor custom matcher to remove repeated code [#8](https://github.com/kevin-j-m/clockwork-test/pull/8)


### PR DESCRIPTION
This updates the testing matrix to consider the latest 2.2, 2.3, and 2.4
ruby point releases for testing evaluation.

Closes #20 