### PR TITLE
Improve manager handling of start/end dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ This specifies the time at which execution of clockwork should terminate. The ru
 
 This is commonly used along with `start_time` and `tick_speed` to quickly see if jobs run as often as expected over a certain period of time.
 
+When `start_time` is set, this setting defaults to `Time.current`.
+
 #### tick_speed
 
 `tick_speed` should be provided as a unit of time, such as `1.minute` or `3.hours`. It is the amount of time that the test will progress time to on every subsequent clock tick.

--- a/lib/clockwork/test/manager.rb
+++ b/lib/clockwork/test/manager.rb
@@ -50,6 +50,8 @@ module Clockwork
           @end_time = Time.current
         end
         @tick_speed = opts[:tick_speed]
+
+        raise "End time can't precede start time." if @start_time && (@start_time > @end_time)
       end
 
       attr_reader :history

--- a/lib/clockwork/test/manager.rb
+++ b/lib/clockwork/test/manager.rb
@@ -6,27 +6,14 @@ module Clockwork
       def initialize(opts = {})
         super()
         @history = JobHistory.new
-
         @total_ticks = 0
-        @max_ticks = opts[:max_ticks]
-        @start_time = opts[:start_time]
-        if opts[:end_time]
-          @end_time = opts[:end_time]
-        elsif @start_time
-          @end_time = Time.current
-        end
+        set_opts(opts)
+
         config[:logger].level = Logger::ERROR
       end
 
       def run(opts = {})
-        @max_ticks = opts[:max_ticks] if opts[:max_ticks]
-        @start_time = opts[:start_time] if opts[:start_time]
-        if opts[:end_time]
-          @end_time = opts[:end_time]
-        elsif @start_time
-          @end_time = Time.current
-        end
-        @tick_speed = opts[:tick_speed]
+        set_opts(opts)
 
         if start_time
           @time_altered = true
@@ -53,6 +40,17 @@ module Clockwork
       end
 
       private
+
+      def set_opts(opts)
+        @max_ticks = opts[:max_ticks] if opts[:max_ticks]
+        @start_time = opts[:start_time] if opts[:start_time]
+        if opts[:end_time]
+          @end_time = opts[:end_time]
+        elsif @start_time
+          @end_time = Time.current
+        end
+        @tick_speed = opts[:tick_speed]
+      end
 
       attr_reader :history
 

--- a/lib/clockwork/test/manager.rb
+++ b/lib/clockwork/test/manager.rb
@@ -1,7 +1,7 @@
 module Clockwork
   module Test
     class Manager < Clockwork::Manager
-      attr_reader :total_ticks, :max_ticks, :end_time
+      attr_reader :total_ticks, :max_ticks, :end_time, :start_time
 
       def initialize(opts = {})
         super()
@@ -10,19 +10,27 @@ module Clockwork
         @total_ticks = 0
         @max_ticks = opts[:max_ticks]
         @start_time = opts[:start_time]
-        @end_time = opts[:end_time]
+        if opts[:end_time]
+          @end_time = opts[:end_time]
+        elsif @start_time
+          @end_time = Time.current
+        end
         config[:logger].level = Logger::ERROR
       end
 
       def run(opts = {})
         @max_ticks = opts[:max_ticks] if opts[:max_ticks]
         @start_time = opts[:start_time] if opts[:start_time]
-        @end_time = opts[:end_time] if opts[:end_time]
+        if opts[:end_time]
+          @end_time = opts[:end_time]
+        elsif @start_time
+          @end_time = Time.current
+        end
         @tick_speed = opts[:tick_speed]
 
-        if @start_time
+        if start_time
           @time_altered = true
-          Timecop.travel(@start_time)
+          Timecop.travel(start_time)
         end
 
         yield if block_given?

--- a/spec/clockwork/test/manager_spec.rb
+++ b/spec/clockwork/test/manager_spec.rb
@@ -8,6 +8,7 @@ describe Clockwork::Test::Manager do
   context "initial state" do
     its(:total_ticks) { should eq 0 }
     its(:max_ticks) { should be_nil }
+    its(:start_time) { should be_nil }
     its(:end_time) { should be_nil }
 
     context "providing a maximum number of ticks" do
@@ -22,6 +23,16 @@ describe Clockwork::Test::Manager do
       let(:end_time) { Time.current }
 
       its(:end_time) { should eq end_time }
+    end
+
+    context "start_time provided, while end_time is not" do
+      let(:opts) { { start_time: 5.minutes.ago } }
+
+      before { Timecop.freeze }
+      after { Timecop.return }
+
+      its(:start_time) { should eq opts[:start_time] }
+      its(:end_time) { should eq Time.current }
     end
   end
 

--- a/spec/clockwork/test/manager_spec.rb
+++ b/spec/clockwork/test/manager_spec.rb
@@ -34,6 +34,14 @@ describe Clockwork::Test::Manager do
       its(:start_time) { should eq opts[:start_time] }
       its(:end_time) { should eq Time.current }
     end
+
+    context "start_time happens after the end_time" do
+      let(:opts) { { start_time: 5.minutes.ago, end_time: 10.minutes.ago } }
+
+      it "raises with useful message" do
+        expect { manager }.to raise_error("End time can't precede start time.")
+      end
+    end
   end
 
   describe "#run" do


### PR DESCRIPTION
The primary user-facing change is that end_time is automatically set to current time when start time is set.

This means that examples could be more elegant, e.g.:

```
    start_time = Time.new(2015, 11, 2, 2, 0, 0)
    end_time = Time.new(2015, 11, 2, 3, 0, 0)

    Clockwork::Test.run(start_time: start_time, end_time: end_time, tick_speed: 1.minute)
```

can be rewritten to 

```
    Clockwork::Test.run(start_time: 1.hour.ago, tick_speed: 1.minute)
```

And it should work/test the same thing with same result.

Though I've not yet added this way of writing code to README. What do you think, @kevin-j-m  ?