### PR TITLE
Fix Appraisal for clockwork 2.0.3

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -17,3 +17,7 @@ end
 appraise "clockwork-2-0-2" do
   gem "clockwork", "2.0.2"
 end
+
+appraise "clockwork-2-0-3" do
+  gem "clockwork", "2.0.3"
+end

--- a/gemfiles/clockwork_2_0_3.gemfile.lock
+++ b/gemfiles/clockwork_2_0_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    clockwork-test (0.2.0)
+    clockwork-test (0.3.0)
       clockwork
       timecop
 


### PR DESCRIPTION
This updates the Appraisal file so that 2.0.3 is included, and the
gemfile.lock for that version includes the latest version of the
clockwork-test gem.