### PR TITLE
[ready] Sync default location w/ clockwork README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ For example, with a `tick_speed` of `30.minutes` and a job that runs every `1.mi
 
 #### file
 
-The location of the clock file to test. This defaults to `"./config/clock.rb"` if a value is not provided.
+The location of the clock file to test. This defaults to `"./clock.rb"` if a value is not provided.
 
 ### Assertions Against Test Runs
 

--- a/lib/clockwork/test.rb
+++ b/lib/clockwork/test.rb
@@ -46,7 +46,7 @@ module Clockwork
 
     module Methods
       def run(opts = {})
-        file = opts[:file] || "./config/clock.rb"
+        file = opts[:file] || "./clock.rb"
 
         run_opts = {
           max_ticks: opts[:max_ticks],


### PR DESCRIPTION
Clockwork README indicate that clock.rb file is under the project root directory, hence I think we should follow suit to avoid surprises.