### PR TITLE
Add support of events without custom block

### DIFF
--- a/lib/clockwork/test.rb
+++ b/lib/clockwork/test.rb
@@ -19,6 +19,11 @@ module Clockwork
       ::Clockwork::Test.manager.configure(&block)
     end
 
+    def handler(&block)
+      ::Clockwork.manager.handler(&block)
+      ::Clockwork::Test.manager.handler(&block)
+    end
+
     def on(event, options={}, &block)
       ::Clockwork.manager.on(event, options, &block)
       ::Clockwork::Test.manager.on(event, options, &block)

--- a/spec/acceptance/clock_spec.rb
+++ b/spec/acceptance/clock_spec.rb
@@ -111,6 +111,17 @@ describe "Clockwork" do
     end
   end
 
+  describe "Run with no custom block" do
+    subject(:clockwork) { Clockwork::Test }
+
+    before(:each) { Clockwork::Test.run(clock_opts) }
+    after(:each) { Clockwork::Test.clear! }
+
+    let(:clock_opts) { { file: clock_file, max_ticks: 1, tick_speed: 1.hour } }
+
+    it { should have_run("JobNamePassedToTheHandler").once }
+  end
+
   if Gem::Version.new("2.0.2") < Gem::Version.new(Gem.loaded_specs["clockwork"].version)
     describe "Runs when skip_first_run is specified" do
       subject(:clockwork) { Clockwork::Test }

--- a/spec/fixtures/clock.rb
+++ b/spec/fixtures/clock.rb
@@ -26,4 +26,6 @@ module Clockwork
   every(1.hour, "Run at 10 past the hour", at: "**:10") do
     "Run at 10 past the hour"
   end
+
+  every(1.hour, "JobNamePassedToTheHandler")
 end


### PR DESCRIPTION
Without `handler` in `Clockwork::Methods`, the `Clockwork::Manager::NoHandlerDefined` exception is raised if clockwork config file includes an event without a custom block.