### PR TITLE
Use timecop in safe mode

### DIFF
--- a/spec/clockwork/test/manager_spec.rb
+++ b/spec/clockwork/test/manager_spec.rb
@@ -28,8 +28,7 @@ describe Clockwork::Test::Manager do
     context "start_time provided, while end_time is not" do
       let(:opts) { { start_time: 5.minutes.ago } }
 
-      before { Timecop.freeze }
-      after { Timecop.return }
+      around { |example| Timecop.freeze(&example) }
 
       its(:start_time) { should eq opts[:start_time] }
       its(:end_time) { should eq Time.current }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,5 @@ require "rspec/its"
 RSpec.configure do |config|
   config.include(Clockwork::Test::RSpec::Matchers)
 end
+
+Timecop.safe_mode = true


### PR DESCRIPTION
I enabled timecop in safe mode (https://github.com/travisjeffery/timecop#timecopsafe_mode) for a project and this gem caused failures since it's not using the block syntax for timecop.

This change makes it pass the `safe_mode` check.