### PR TITLE
Run clock at least once when start == end date

### DIFF
--- a/lib/clockwork/test/manager.rb
+++ b/lib/clockwork/test/manager.rb
@@ -59,7 +59,7 @@ module Clockwork
       def tick_loop
         loop.with_index do |_, index|
           Timecop.travel(Time.current + @tick_speed.to_i * index) do
-            return if ticks_exceeded? || time_exceeded?
+            return if ticks_exceeded? || (time_exceeded? && index > 0)
 
             update_job_history
             tick

--- a/spec/clockwork/test/manager_spec.rb
+++ b/spec/clockwork/test/manager_spec.rb
@@ -82,6 +82,15 @@ describe Clockwork::Test::Manager do
           expect(manager.total_ticks).to be > 0
         end
       end
+
+      context "with same start and end time" do
+        let(:end_time) { Time.current }
+
+        it "runs the clock once" do
+          manager.run
+          expect(manager.total_ticks).to eq 1
+        end
+      end
     end
 
     context "recording job history" do


### PR DESCRIPTION
This restores the behaviour prior to version 0.5.0 that specifying the same start and end date would at least lead to a single tick.

This was changed through 19057cb47bc22c9bd5715bf94c6b6b1d11ff72f0.

This also adds a regression test.